### PR TITLE
Fixes to game start-up

### DIFF
--- a/maze.py
+++ b/maze.py
@@ -10,18 +10,18 @@ class Cell:
         self.size = size
         self.walls = {'top': True, 'right': True, 'bottom': True, 'left': True}
         self.visited = False
+        self.thickness = 2
 
-    def draw(self, screen):
-        x = self.x * self.size
-        y = self.y * self.size
+    def draw(self, sc, tile, offset_y=0):
+        x, y = self.x * tile, (self.y * tile) + offset_y
         if self.walls['top']:
-            pygame.draw.line(screen, (255, 255, 255), (x, y), (x + self.size, y), 2)
+            pygame.draw.line(sc, pygame.Color('darkgreen'), (x, y), (x + tile, y), self.thickness) # thickness of the wall
         if self.walls['right']:
-            pygame.draw.line(screen, (255, 255, 255), (x + self.size, y), (x + self.size, y + self.size), 2)
+            pygame.draw.line(sc, pygame.Color('darkgreen'), (x + tile, y), (x + tile, y + tile), self.thickness)
         if self.walls['bottom']:
-            pygame.draw.line(screen, (255, 255, 255), (x + self.size, y + self.size), (x, y + self.size), 2)
+            pygame.draw.line(sc, pygame.Color('darkgreen'), (x + tile, y + tile), (x, y + tile), self.thickness)
         if self.walls['left']:
-            pygame.draw.line(screen, (255, 255, 255), (x, y + self.size), (x, y), 2)
+            pygame.draw.line(sc, pygame.Color('darkgreen'), (x, y + tile), (x, y), self.thickness)
 
     def remove_wall(self, next_cell):
         dx = self.x - next_cell.x
@@ -48,10 +48,10 @@ class Maze:
         self.stack = []
         self.current = self.grid[0][0]
 
-    def draw(self, screen):
+    def draw(self, screen, offset_y=0):
         for col in range(self.cols):
             for row in range(self.rows):
-                self.grid[col][row].draw(screen)
+                self.grid[col][row].draw(screen, offset_y) # draw grid cell walls
 
     def generate_maze(self):
         self.current.visited = True

--- a/player.py
+++ b/player.py
@@ -133,7 +133,6 @@ class Player:
 
         return True
 
-
     def get_neighbors(self, x, y, grid_cells):
         neighbors = []
         if x < len(grid_cells) - 1 and not grid_cells[x + 1][y].walls['left']:


### PR DESCRIPTION
Errors occurring during start-up have been corrected.
In [`maze.py`](./maze.py), `thickenss` is now provided so that the game is drawn correctly.

Also, in [`maze.draw`](https://github.com/shiki-01/Maze-Duel/blob/00b948465ae38fe155655513361de1e40f1ee593/maze.py#L18), 
only screen was specified when two arguments were required, so `offset_y` was added as a new argument.


However, when playing the game after these fixes, we also found a bug related to player movement, which was not fixed in this PR as it could not be resolved immediately.